### PR TITLE
[Rule] add directory ignore option

### DIFF
--- a/Editor/AddressableImportRule.cs
+++ b/Editor/AddressableImportRule.cs
@@ -102,6 +102,13 @@ public class AddressableImportRule
     [ConditionalField("matchType", AddressableImportRuleMatchType.Regex, "simplified", false)]
     public string addressReplacement = string.Empty;
 
+    /// <summary>
+    /// Ignore Flag to be directory as a Addressable
+    /// </summary>
+    [Tooltip("Ignore Flag: directory not to be a Addressable")]
+    [Label("Ignore Directory as a Addressable")]
+    public bool IgnoreDirectory = true;
+
     public bool HasLabel
     {
         get

--- a/Editor/AddressableImporter.cs
+++ b/Editor/AddressableImporter.cs
@@ -183,6 +183,10 @@ public class AddressableImporter : AssetPostprocessor
         {
             if (!r.Match(assetPath))
                 continue;
+
+            if(r.IgnoreDirectory && ((File.GetAttributes(assetPath) & FileAttributes.Directory) == FileAttributes.Directory))
+	            continue;
+	        
             rule = r;
             return true;
         }


### PR DESCRIPTION
# TL;DR
Optional rule for ignore directory as a addressable.

# Detail
It is difficult to express to ignore directory, especially recursive search and register addressables.

Furthermore, in large Unity Project, there are many addressable file and directories, directory addressable is meaningless and consumes assetbundle file size.

So adding new rule to check ignore directory.
