### PR TITLE
[Bugfix] UPM cannot parse alphabet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.9.4a](https://github.com/Graffity-X/unity-addressable-importer/compare/v0.9.3...v0.9.4a) (2020-10-17)
+## [0.9.4](https://github.com/Graffity-X/unity-addressable-importer/compare/v0.9.3...v0.9.4) (2020-12-14)
 
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.littlebigfun.addressable-importer",
   "displayName": "Unity Addressable Importer",
-  "version": "0.9.4a",
+  "version": "0.9.4",
   "unity": "2018.3",
   "description": "A simple rule based addressable asset importer.",
   "dependencies": {


### PR DESCRIPTION
UPM cant parse alphabet word like `0.0.1a`